### PR TITLE
Add osx support for install rokit task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -15,10 +15,7 @@
                     }
                 }
             },
-            // maybe works? untested
-            "linux": {
-                "command": "chmod +x ${workspaceFolder}/scripts/rokit_install.sh && ${workspaceFolder}/scripts/rokit_install.sh"
-            },
+            "command": "chmod +x ${workspaceFolder}/scripts/rokit_install.sh && ${workspaceFolder}/scripts/rokit_install.sh",
             "presentation": {
                 "echo": true,
                 "reveal": "always",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ uh template I guess.
 
 ## installation
 
-run vsc "install" task
+1. in vsc, press shift+p
+2. type "task install"
+
+this will install rokit and along with all tools below
 
 ## tools
 


### PR DESCRIPTION
This will continue to work for linux despite removing the specific linux header